### PR TITLE
Change $EXT_BUILD_DEPS dir to support multi-arch builds

### DIFF
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -232,7 +232,7 @@ def cc_external_rule_impl(ctx, attrs):
         set_cc_envs,
         "export EXT_BUILD_ROOT=##pwd##",
         "export BUILD_TMPDIR=##tmpdir##",
-        "export EXT_BUILD_DEPS=$$EXT_BUILD_ROOT$$/bazel_foreign_cc_deps_" + lib_name,
+        "export EXT_BUILD_DEPS=$$EXT_BUILD_ROOT$$/" + empty.file.dirname + "/bazel_foreign_cc_deps_" + lib_name,
         "export INSTALLDIR=$$EXT_BUILD_ROOT$$/" + empty.file.dirname + "/" + lib_name,
     ]
 


### PR DESCRIPTION
This was set to `$EXT_BUILD_ROOT/bazel_foreign_cc_deps_" + lib_name`.
When building the same target (cmake, etc.) for multiple architectures, the
deps for each architecture try to link over each other, failing the build.

Make this dir relative to the target's dir in the exec root - then the target's
deps are constrained to its output dir